### PR TITLE
Create turkey.cmd / add a .cmd file that comes with with -4 option which works for turkey

### DIFF
--- a/turkey.cmd
+++ b/turkey.cmd
@@ -1,0 +1,16 @@
+@ECHO OFF
+PUSHD "%~dp0"
+set _arch=x86
+IF "%PROCESSOR_ARCHITECTURE%"=="AMD64" (set _arch=x86_64)
+IF DEFINED PROCESSOR_ARCHITEW6432 (set _arch=x86_64)
+
+echo Sag tikla admin olarak calistir
+echo Admin olarak calistirdiysan bir tusa bas
+pause
+sc stop "GoodbyeDPI"
+sc delete "GoodbyeDPI"
+sc create "GoodbyeDPI" binPath= "\"%CD%\%_arch%\goodbyedpi.exe\" -4" start= "auto"
+sc description "GoodbyeDPI" "Passive Deep Packet Inspection blocker and Active DPI circumvention utility"
+sc start "GoodbyeDPI"
+
+POPD


### PR DESCRIPTION
```
@ECHO OFF
PUSHD "%~dp0"
set _arch=x86
IF "%PROCESSOR_ARCHITECTURE%"=="AMD64" (set _arch=x86_64)
IF DEFINED PROCESSOR_ARCHITEW6432 (set _arch=x86_64)

echo Sag tikla admin olarak calistir
echo Admin olarak calistirdiysan bir tusa bas
pause
sc stop "GoodbyeDPI"
sc delete "GoodbyeDPI"
sc create "GoodbyeDPI" binPath= "\"%CD%\%_arch%\goodbyedpi.exe\" -4" start= "auto"
sc description "GoodbyeDPI" "Passive Deep Packet Inspection blocker and Active DPI circumvention utility"
sc start "GoodbyeDPI"

POPD
```

there is no .cmd for -4 (fastest) setting. a cmd like this works on 4 turkish ISPs and possibly on all of the Turkish ISPs (tested on Türknet , Türk Telekom, Superonline and Vodafone)
