### PR TITLE
Ipv6 DPI tcp.Rst fix

### DIFF
--- a/src/goodbyedpi.c
+++ b/src/goodbyedpi.c
@@ -76,11 +76,11 @@ WINSOCK_API_LINKAGE INT WSAAPI inet_pton(INT Family, LPCSTR pStringBuf, PVOID pA
          "(tcp.DstPort == 80 or tcp.DstPort == 443) and tcp.Ack and " \
          "(" DIVERT_NO_LOCALNETSv4_DST " or " DIVERT_NO_LOCALNETSv6_DST "))" \
         "))"
-#define FILTER_PASSIVE_STRING_TEMPLATE "inbound and ip and tcp and " \
+#define FILTER_PASSIVE_STRING_TEMPLATE "inbound and tcp and " \
         "!impostor and !loopback and " \
-        "((ip.Id <= 0xF and ip.Id >= 0x0) " IPID_TEMPLATE ") and " \
+        "(ipv6 or (ip.Id <= 0xF and ip.Id >= 0x0) " IPID_TEMPLATE ") and " \
         "(tcp.SrcPort == 443 or tcp.SrcPort == 80) and tcp.Rst and " \
-        DIVERT_NO_LOCALNETSv4_SRC
+        "(" DIVERT_NO_LOCALNETSv4_DST " or " DIVERT_NO_LOCALNETSv6_DST ")"
 
 #define SET_HTTP_FRAGMENT_SIZE_OPTION(fragment_size) do { \
     if (!http_fragment_size) { \


### PR DESCRIPTION
На ртк с недавних пор стал проходить ipv6 TCP Reset на rutracker.org, сделал небольшой фикс. Но пока не до конца понимаю, какая замена ip.Id должна быть для ipv6 в данном фильтре.