### PR TITLE
Add --no-console argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ Usage: goodbyedpi.exe [OPTION...]
                           (like file transfers) in already established sessions.
                           May skip some huge HTTP requests from being processed.
                           Default (if set): --max-payload 1200.
- --no-console             Hides console window :)
 
 
 LEGACY modesets:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Usage: goodbyedpi.exe [OPTION...]
                           (like file transfers) in already established sessions.
                           May skip some huge HTTP requests from being processed.
                           Default (if set): --max-payload 1200.
+ --no-console             Hides console window :)
 
 
 LEGACY modesets:

--- a/src/goodbyedpi.c
+++ b/src/goodbyedpi.c
@@ -170,27 +170,27 @@ static const char *http_methods[] = {
 };
 
 static struct option long_options[] = {
-    {"port",            required_argument, 0,  'z' },
-    {"dns-addr",        required_argument, 0,  'd' },
-    {"dns-port",        required_argument, 0,  'g' },
-    {"dnsv6-addr",      required_argument, 0,  '!' },
-    {"dnsv6-port",      required_argument, 0,  '@' },
-    {"dns-verb",        no_argument,       0,  'v' },
-    {"blacklist",       required_argument, 0,  'b' },
-    {"allow-no-sni",    no_argument,       0,  ']' },
-    {"frag-by-sni",     no_argument,       0,  '>' },
-    {"ip-id",           required_argument, 0,  'i' },
-    {"set-ttl",         required_argument, 0,  '$' },
-    {"min-ttl",         required_argument, 0,  '[' },
-    {"auto-ttl",        optional_argument, 0,  '+' },
-    {"wrong-chksum",    no_argument,       0,  '%' },
-    {"wrong-seq",       no_argument,       0,  ')' },
-    {"native-frag",     no_argument,       0,  '*' },
-    {"reverse-frag",    no_argument,       0,  '(' },
-    {"max-payload",     optional_argument, 0,  '|' },
-    {"debug-no-console",optional_argument, 0,  'c' },
-    {"debug-exit",      optional_argument, 0,  '?' },
-    {0,                 0,                 0,   0  }
+    {"port",        required_argument, 0,  'z' },
+    {"dns-addr",    required_argument, 0,  'd' },
+    {"dns-port",    required_argument, 0,  'g' },
+    {"dnsv6-addr",  required_argument, 0,  '!' },
+    {"dnsv6-port",  required_argument, 0,  '@' },
+    {"dns-verb",    no_argument,       0,  'v' },
+    {"blacklist",   required_argument, 0,  'b' },
+    {"allow-no-sni",no_argument,       0,  ']' },
+    {"frag-by-sni", no_argument,       0,  '>' },
+    {"ip-id",       required_argument, 0,  'i' },
+    {"set-ttl",     required_argument, 0,  '$' },
+    {"min-ttl",     required_argument, 0,  '[' },
+    {"auto-ttl",    optional_argument, 0,  '+' },
+    {"wrong-chksum",no_argument,       0,  '%' },
+    {"wrong-seq",   no_argument,       0,  ')' },
+    {"native-frag", no_argument,       0,  '*' },
+    {"reverse-frag",no_argument,       0,  '(' },
+    {"max-payload", optional_argument, 0,  '|' },
+    {"debug-no-console", optional_argument, 0, 'c'},
+    {"debug-exit",  optional_argument, 0,  '?' },
+    {0,             0,                 0,   0  }
 };
 
 static char *filter_string = NULL;

--- a/src/goodbyedpi.c
+++ b/src/goodbyedpi.c
@@ -23,7 +23,7 @@
 // My mingw installation does not load inet_pton definition for some reason
 WINSOCK_API_LINKAGE INT WSAAPI inet_pton(INT Family, LPCSTR pStringBuf, PVOID pAddr);
 
-#define GOODBYEDPI_VERSION "v0.2.3"
+#define GOODBYEDPI_VERSION "v0.2.4"
 
 #define die() do { sleep(20); exit(EXIT_FAILURE); } while (0)
 
@@ -187,6 +187,7 @@ static struct option long_options[] = {
     {"native-frag", no_argument,       0,  '*' },
     {"reverse-frag",no_argument,       0,  '(' },
     {"max-payload", optional_argument, 0,  '|' },
+    {"no-console",  optional_argument, 0,  'c' },
     {0,             0,                 0,   0  }
 };
 
@@ -937,6 +938,10 @@ int main(int argc, char *argv[]) {
                 else
                     max_payload_size = 1200;
                 break;
+            case 'c': // --no-console
+                if (GetConsoleWindow() != NULL)
+                    FreeConsole();
+                break;
             default:
                 puts("Usage: goodbyedpi.exe [OPTION...]\n"
                 " -p          block passive DPI\n"
@@ -987,6 +992,7 @@ int main(int argc, char *argv[]) {
                 "                          (like file transfers) in already established sessions.\n"
                 "                          May skip some huge HTTP requests from being processed.\n"
                 "                          Default (if set): --max-payload 1200.\n"
+                " --no-console             Hides console window :)\n"
                 "\n");
                 puts("LEGACY modesets:\n"
                 " -1          -p -r -s -f 2 -k 2 -n -e 2 (most compatible mode)\n"


### PR DESCRIPTION
Потому-что некоторые(или даже многие) люди любят добавлять GoodbyeDPI в автозапуск, мы можем добавить аргумент --no-console, что-бы избавиться от консоли которая во время работы может даже мешать некоторым(да и она ничего не логает во время работы) и наслаждаться с GoodbyeDPI в бекграунде!