### PR TITLE
Runtime debug log (getenv way )

### DIFF
--- a/src/goodbyedpi.c
+++ b/src/goodbyedpi.c
@@ -574,8 +574,7 @@ static void send_native_fragment(HANDLE w_filter, WINDIVERT_ADDRESS addr,
 }
 
 int main(int argc, char *argv[]) {
-    printf("Debug mode is %s",getenv("DEBUG_GDPI"));
-    debug("Debug mode enabled");
+    debug("Debug mode enabled\n\n");
     static enum packet_type_e {
         unknown,
         ipv4_tcp, ipv4_tcp_data, ipv4_udp_data,

--- a/src/goodbyedpi.c
+++ b/src/goodbyedpi.c
@@ -574,6 +574,7 @@ static void send_native_fragment(HANDLE w_filter, WINDIVERT_ADDRESS addr,
 }
 
 int main(int argc, char *argv[]) {
+    printf("Debug mode is %s",getenv("DEBUG_GDPI"));
     debug("Debug mode enabled");
     static enum packet_type_e {
         unknown,

--- a/src/goodbyedpi.c
+++ b/src/goodbyedpi.c
@@ -574,6 +574,7 @@ static void send_native_fragment(HANDLE w_filter, WINDIVERT_ADDRESS addr,
 }
 
 int main(int argc, char *argv[]) {
+    debug("Debug mode enabled");
     static enum packet_type_e {
         unknown,
         ipv4_tcp, ipv4_tcp_data, ipv4_udp_data,

--- a/src/goodbyedpi.h
+++ b/src/goodbyedpi.h
@@ -6,6 +6,6 @@
 // #else
 // #define debug(...) printf(__VA_ARGS__)
 // #endif
-#define debug(...) if (getenv("DEBUG_GDPI")!=NULL) printf(__VA_ARGS__)
+#define debug(...) if (getenv("DEBUG_GDPI") != NULL) printf(__VA_ARGS__)
 int main(int argc, char *argv[]);
 void deinit_all();

--- a/src/goodbyedpi.h
+++ b/src/goodbyedpi.h
@@ -1,11 +1,11 @@
 #define HOST_MAXLEN 253
 #define MAX_PACKET_SIZE 9016
 
-#ifndef DEBUG
-#define debug(...) do {} while (0)
-#else
-#define debug(...) printf(__VA_ARGS__)
-#endif
-
+// #ifndef DEBUG
+// #define debug(...) do {} while (0)
+// #else
+// #define debug(...) printf(__VA_ARGS__)
+// #endif
+#define debug(...) if (getenv("DEBUG_GDPI")!=NULL) printf(__VA_ARGS__)
 int main(int argc, char *argv[]);
 void deinit_all();


### PR DESCRIPTION
Added getenv() call in debug macro.
Checks only existence of variable.
Start with admin to use.
Add set DEBUG_GDPI=<smthg>