### PR TITLE
Fix warning: 'tcp_handle_outgoing' accessing 16 bytes in a region of 4

### DIFF
--- a/src/dnsredir.c
+++ b/src/dnsredir.c
@@ -197,8 +197,8 @@ int dns_is_dns_packet(const char *packet_data, const UINT packet_dataLen, const 
     return FALSE;
 }
 
-int dns_handle_outgoing(const uint32_t srcip[4], const uint16_t srcport,
-                        const uint32_t dstip[4], const uint16_t dstport,
+int dns_handle_outgoing(const uint32_t* srcip, const uint16_t srcport,
+                        const uint32_t* dstip, const uint16_t dstport,
                         const char *packet_data, const UINT packet_dataLen,
                         const uint8_t is_ipv6)
 {
@@ -216,7 +216,7 @@ int dns_handle_outgoing(const uint32_t srcip[4], const uint16_t srcport,
     return FALSE;
 }
 
-int dns_handle_incoming(const uint32_t srcip[4], const uint16_t srcport,
+int dns_handle_incoming(const uint32_t* srcip, const uint16_t srcport,
                         const char *packet_data, const UINT packet_dataLen,
                         conntrack_info_t *conn_info, const uint8_t is_ipv6)
 {

--- a/src/dnsredir.h
+++ b/src/dnsredir.h
@@ -24,12 +24,12 @@ inline static void ipv6_copy_addr(uint32_t dst[4], const uint32_t src[4]) {
     dst[3] = src[3];
 }
 
-int dns_handle_incoming(const uint32_t srcip[4], const uint16_t srcport,
+int dns_handle_incoming(const uint32_t* srcip, const uint16_t srcport,
                         const char *packet_data, const UINT packet_dataLen,
                         conntrack_info_t *conn_info, const uint8_t is_ipv6);
 
-int dns_handle_outgoing(const uint32_t srcip[4], const uint16_t srcport,
-                        const uint32_t dstip[4], const uint16_t dstport,
+int dns_handle_outgoing(const uint32_t* srcip, const uint16_t srcport,
+                        const uint32_t* dstip, const uint16_t dstport,
                         const char *packet_data, const UINT packet_dataLen,
                         const uint8_t is_ipv6
                        );

--- a/src/goodbyedpi.c
+++ b/src/goodbyedpi.c
@@ -1152,7 +1152,7 @@ int main(int argc, char *argv[]) {
         filter_num++;
     }
 
-    /* 
+    /*
      * IPv4 & IPv6 filter for inbound HTTP redirection packets and
      * active DPI circumvention
      */
@@ -1294,7 +1294,7 @@ int main(int argc, char *argv[]) {
                     }
                 }
                 /* Handle OUTBOUND packet on port 80, search for Host header */
-                else if (addr.Outbound && 
+                else if (addr.Outbound &&
                         packet_dataLen > 16 &&
                         (do_http_allports ? 1 : (ppTcpHdr->DstPort == htons(80))) &&
                         find_http_method_end(packet_data,
@@ -1455,8 +1455,8 @@ int main(int argc, char *argv[]) {
                                         ppTcpHdr->SrcPort, ppTcpHdr->DstPort,
                                         0, ppIpHdr->TTL))
                             ||
-                            (packet_v6 && tcp_handle_incoming((uint32_t*)&ppIpV6Hdr->SrcAddr,
-                                        (uint32_t*)&ppIpV6Hdr->DstAddr,
+                            (packet_v6 && tcp_handle_incoming(ppIpV6Hdr->SrcAddr,
+                                        ppIpV6Hdr->DstAddr,
                                         ppTcpHdr->SrcPort, ppTcpHdr->DstPort,
                                         1, ppIpV6Hdr->HopLimit))))
                         {

--- a/src/ttltrack.c
+++ b/src/ttltrack.c
@@ -39,8 +39,8 @@ typedef struct tcp_connrecord {
 static time_t last_cleanup = 0;
 static tcp_connrecord_t *conntrack = NULL;
 
-inline static void fill_key_data(char *key, const uint8_t is_ipv6, const uint32_t srcip[4],
-                    const uint32_t dstip[4], const uint16_t srcport, const uint16_t dstport)
+inline static void fill_key_data(char *key, const uint8_t is_ipv6, const uint32_t* srcip,
+                    const uint32_t* dstip, const uint16_t srcport, const uint16_t dstport)
 {
     unsigned int offset = 0;
 
@@ -94,7 +94,7 @@ inline static void fill_data_from_key(uint8_t *is_ipv6, uint32_t srcip[4], uint3
     offset += sizeof(*dstport);
 }
 
-inline static void construct_key(const uint32_t srcip[4], const uint32_t dstip[4],
+inline static void construct_key(const uint32_t* srcip, const uint32_t* dstip,
                                  const uint16_t srcport, const uint16_t dstport,
                                  char *key, const uint8_t is_ipv6)
 {
@@ -137,7 +137,7 @@ static int check_get_tcp_conntrack_key(const char *key, tcp_connrecord_t **connr
     return FALSE;
 }
 
-static int add_tcp_conntrack(const uint32_t srcip[4], const uint32_t dstip[4],
+static int add_tcp_conntrack(const uint32_t* srcip, const uint32_t* dstip,
                              const uint16_t srcport, const uint16_t dstport,
                              const uint8_t is_ipv6, const uint8_t ttl
                             )
@@ -180,7 +180,7 @@ static void tcp_cleanup() {
     }
 }
 
-int tcp_handle_incoming(uint32_t srcip[4], uint32_t dstip[4],
+int tcp_handle_incoming(const uint32_t* srcip, const uint32_t* dstip,
                         uint16_t srcport, uint16_t dstport,
                         uint8_t is_ipv6, uint8_t ttl)
 {
@@ -193,7 +193,7 @@ int tcp_handle_incoming(uint32_t srcip[4], uint32_t dstip[4],
     return FALSE;
 }
 
-int tcp_handle_outgoing(uint32_t srcip[4], uint32_t dstip[4],
+int tcp_handle_outgoing(const uint32_t* srcip, const uint32_t* dstip,
                         uint16_t srcport, uint16_t dstport,
                         tcp_conntrack_info_t *conn_info,
                         uint8_t is_ipv6)

--- a/src/ttltrack.h
+++ b/src/ttltrack.h
@@ -12,11 +12,11 @@ typedef struct tcp_conntrack_info {
     uint16_t dstport;
 } tcp_conntrack_info_t;
 
-int tcp_handle_incoming(uint32_t srcip[4], uint32_t dstip[4],
+int tcp_handle_incoming(const uint32_t* srcip, const uint32_t* dstip,
                         uint16_t srcport, uint16_t dstport,
                         uint8_t is_ipv6, uint8_t ttl);
 
-int tcp_handle_outgoing(uint32_t srcip[4], uint32_t dstip[4],
+int tcp_handle_outgoing(const uint32_t* srcip, const uint32_t* dstip,
                         uint16_t srcport, uint16_t dstport,
                         tcp_conntrack_info_t *conn_info,
                         uint8_t is_ipv6);


### PR DESCRIPTION
Fixed compilations warnings in functions tcp_handle_outgoing, tcp_handle_incoming, dns_handle_incoming, dns_handle_outgoing.
<details><summary>Details</summary>
<p>

goodbyedpi.c:104:23: warning: 'tcp_handle_outgoing' accessing 16 bytes in a region of size 4 [-Wstringop-overflow=]
  104 |     if ((packet_v4 && tcp_handle_outgoing(&ppIpHdr->SrcAddr, &ppIpHdr->DstAddr, \
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  105 |                         ppTcpHdr->SrcPort, ppTcpHdr->DstPort, \
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  106 |                         &tcp_conn_info, 0)) \
      |                         ~~~~~~~~~~~~~~~~~~
goodbyedpi.c:115:9: note: in expansion of macro 'TCP_HANDLE_OUTGOING_TTL_PARSE_PACKET_IF'
  115 |         TCP_HANDLE_OUTGOING_TTL_PARSE_PACKET_IF() { \
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
goodbyedpi.c:1287:33: note: in expansion of macro 'TCP_HANDLE_OUTGOING_FAKE_PACKET'
 1287 |                                 TCP_HANDLE_OUTGOING_FAKE_PACKET(send_fake_https_request);
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
goodbyedpi.c:104:23: note: referencing argument 1 of type 'uint32_t[4]' {aka 'unsigned int[4]'}
  104 |     if ((packet_v4 && tcp_handle_outgoing(&ppIpHdr->SrcAddr, &ppIpHdr->DstAddr, \
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  105 |                         ppTcpHdr->SrcPort, ppTcpHdr->DstPort, \
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  106 |                         &tcp_conn_info, 0)) \
      |                         ~~~~~~~~~~~~~~~~~~
goodbyedpi.c:115:9: note: in expansion of macro 'TCP_HANDLE_OUTGOING_TTL_PARSE_PACKET_IF'
  115 |         TCP_HANDLE_OUTGOING_TTL_PARSE_PACKET_IF() { \
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
goodbyedpi.c:1287:33: note: in expansion of macro 'TCP_HANDLE_OUTGOING_FAKE_PACKET'
 1287 |                                 TCP_HANDLE_OUTGOING_FAKE_PACKET(send_fake_https_request);
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
goodbyedpi.c:104:23: warning: 'tcp_handle_outgoing' accessing 16 bytes in a region of size 4 [-Wstringop-overflow=]
  104 |     if ((packet_v4 && tcp_handle_outgoing(&ppIpHdr->SrcAddr, &ppIpHdr->DstAddr, \
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  105 |                         ppTcpHdr->SrcPort, ppTcpHdr->DstPort, \
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  106 |                         &tcp_conn_info, 0)) \
      |                         ~~~~~~~~~~~~~~~~~~
goodbyedpi.c:115:9: note: in expansion of macro 'TCP_HANDLE_OUTGOING_TTL_PARSE_PACKET_IF'
  115 |         TCP_HANDLE_OUTGOING_TTL_PARSE_PACKET_IF() { \
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
goodbyedpi.c:1287:33: note: in expansion of macro 'TCP_HANDLE_OUTGOING_FAKE_PACKET'
 1287 |                                 TCP_HANDLE_OUTGOING_FAKE_PACKET(send_fake_https_request);
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
goodbyedpi.c:104:23: note: referencing argument 2 of type 'uint32_t[4]' {aka 'unsigned int[4]'}
  104 |     if ((packet_v4 && tcp_handle_outgoing(&ppIpHdr->SrcAddr, &ppIpHdr->DstAddr, \
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  105 |                         ppTcpHdr->SrcPort, ppTcpHdr->DstPort, \
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  106 |                         &tcp_conn_info, 0)) \
      |                         ~~~~~~~~~~~~~~~~~~
goodbyedpi.c:115:9: note: in expansion of macro 'TCP_HANDLE_OUTGOING_TTL_PARSE_PACKET_IF'
  115 |         TCP_HANDLE_OUTGOING_TTL_PARSE_PACKET_IF() { \
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
goodbyedpi.c:1287:33: note: in expansion of macro 'TCP_HANDLE_OUTGOING_FAKE_PACKET'
 1287 |                                 TCP_HANDLE_OUTGOING_FAKE_PACKET(send_fake_https_request);
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from goodbyedpi.c:20:
ttltrack.h:19:5: note: in a call to function 'tcp_handle_outgoing'
   19 | int tcp_handle_outgoing(uint32_t srcip[4], uint32_t dstip[4],
      |     ^~~~~~~~~~~~~~~~~~~
goodbyedpi.c:104:23: warning: 'tcp_handle_outgoing' accessing 16 bytes in a region of size 4 [-Wstringop-overflow=]
  104 |     if ((packet_v4 && tcp_handle_outgoing(&ppIpHdr->SrcAddr, &ppIpHdr->DstAddr, \
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  105 |                         ppTcpHdr->SrcPort, ppTcpHdr->DstPort, \
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  106 |                         &tcp_conn_info, 0)) \
      |                         ~~~~~~~~~~~~~~~~~~
goodbyedpi.c:115:9: note: in expansion of macro 'TCP_HANDLE_OUTGOING_TTL_PARSE_PACKET_IF'
  115 |         TCP_HANDLE_OUTGOING_TTL_PARSE_PACKET_IF() { \
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
goodbyedpi.c:1328:29: note: in expansion of macro 'TCP_HANDLE_OUTGOING_FAKE_PACKET'
 1328 |                             TCP_HANDLE_OUTGOING_FAKE_PACKET(send_fake_http_request);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
goodbyedpi.c:104:23: note: referencing argument 1 of type 'uint32_t[4]' {aka 'unsigned int[4]'}
  104 |     if ((packet_v4 && tcp_handle_outgoing(&ppIpHdr->SrcAddr, &ppIpHdr->DstAddr, \
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  105 |                         ppTcpHdr->SrcPort, ppTcpHdr->DstPort, \
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  106 |                         &tcp_conn_info, 0)) \
      |                         ~~~~~~~~~~~~~~~~~~
goodbyedpi.c:115:9: note: in expansion of macro 'TCP_HANDLE_OUTGOING_TTL_PARSE_PACKET_IF'
  115 |         TCP_HANDLE_OUTGOING_TTL_PARSE_PACKET_IF() { \
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
goodbyedpi.c:1328:29: note: in expansion of macro 'TCP_HANDLE_OUTGOING_FAKE_PACKET'
 1328 |                             TCP_HANDLE_OUTGOING_FAKE_PACKET(send_fake_http_request);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
goodbyedpi.c:104:23: warning: 'tcp_handle_outgoing' accessing 16 bytes in a region of size 4 [-Wstringop-overflow=]
  104 |     if ((packet_v4 && tcp_handle_outgoing(&ppIpHdr->SrcAddr, &ppIpHdr->DstAddr, \
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  105 |                         ppTcpHdr->SrcPort, ppTcpHdr->DstPort, \
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  106 |                         &tcp_conn_info, 0)) \
      |                         ~~~~~~~~~~~~~~~~~~
goodbyedpi.c:115:9: note: in expansion of macro 'TCP_HANDLE_OUTGOING_TTL_PARSE_PACKET_IF'
  115 |         TCP_HANDLE_OUTGOING_TTL_PARSE_PACKET_IF() { \
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
goodbyedpi.c:1328:29: note: in expansion of macro 'TCP_HANDLE_OUTGOING_FAKE_PACKET'
 1328 |                             TCP_HANDLE_OUTGOING_FAKE_PACKET(send_fake_http_request);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
goodbyedpi.c:104:23: note: referencing argument 2 of type 'uint32_t[4]' {aka 'unsigned int[4]'}
  104 |     if ((packet_v4 && tcp_handle_outgoing(&ppIpHdr->SrcAddr, &ppIpHdr->DstAddr, \
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  105 |                         ppTcpHdr->SrcPort, ppTcpHdr->DstPort, \
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  106 |                         &tcp_conn_info, 0)) \
      |                         ~~~~~~~~~~~~~~~~~~
goodbyedpi.c:115:9: note: in expansion of macro 'TCP_HANDLE_OUTGOING_TTL_PARSE_PACKET_IF'
  115 |         TCP_HANDLE_OUTGOING_TTL_PARSE_PACKET_IF() { \
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
goodbyedpi.c:1328:29: note: in expansion of macro 'TCP_HANDLE_OUTGOING_FAKE_PACKET'
 1328 |                             TCP_HANDLE_OUTGOING_FAKE_PACKET(send_fake_http_request);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ttltrack.h:19:5: note: in a call to function 'tcp_handle_outgoing'
   19 | int tcp_handle_outgoing(uint32_t srcip[4], uint32_t dstip[4],
      |     ^~~~~~~~~~~~~~~~~~~
goodbyedpi.c:1454:45: warning: 'tcp_handle_incoming' accessing 16 bytes in a region of size 4 [-Wstringop-overflow=]
 1454 |                         if (!((packet_v4 && tcp_handle_incoming(&ppIpHdr->SrcAddr, &ppIpHdr->DstAddr,
      |                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1455 |                                         ppTcpHdr->SrcPort, ppTcpHdr->DstPort,
      |                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1456 |                                         0, ppIpHdr->TTL))
      |                                         ~~~~~~~~~~~~~~~~
goodbyedpi.c:1454:45: note: referencing argument 1 of type 'uint32_t[4]' {aka 'unsigned int[4]'}
goodbyedpi.c:1454:45: warning: 'tcp_handle_incoming' accessing 16 bytes in a region of size 4 [-Wstringop-overflow=]
goodbyedpi.c:1454:45: note: referencing argument 2 of type 'uint32_t[4]' {aka 'unsigned int[4]'}
ttltrack.h:15:5: note: in a call to function 'tcp_handle_incoming'
   15 | int tcp_handle_incoming(uint32_t srcip[4], uint32_t dstip[4],
      |     ^~~~~~~~~~~~~~~~~~~
goodbyedpi.c:1486:39: warning: 'dns_handle_incoming' reading 16 bytes from a region of size 4 [-Wstringop-overread]
 1486 |                     if ((packet_v4 && dns_handle_incoming(&ppIpHdr->DstAddr, ppUdpHdr->DstPort,
      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1487 |                                         packet_data, packet_dataLen,
      |                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1488 |                                         &dns_conn_info, 0))
      |                                         ~~~~~~~~~~~~~~~~~~
goodbyedpi.c:1486:39: note: referencing argument 1 of type 'const uint32_t[4]' {aka 'const unsigned int[4]'}
In file included from goodbyedpi.c:19:
dnsredir.h:27:5: note: in a call to function 'dns_handle_incoming'
   27 | int dns_handle_incoming(const uint32_t srcip[4], const uint16_t srcport,
      |     ^~~~~~~~~~~~~~~~~~~
goodbyedpi.c:1516:39: warning: 'dns_handle_outgoing' reading 16 bytes from a region of size 4 [-Wstringop-overread]
 1516 |                     if ((packet_v4 && dns_handle_outgoing(&ppIpHdr->SrcAddr, ppUdpHdr->SrcPort,
      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1517 |                                         &ppIpHdr->DstAddr, ppUdpHdr->DstPort,
      |                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1518 |                                         packet_data, packet_dataLen, 0))
      |                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
goodbyedpi.c:1516:39: note: referencing argument 1 of type 'const uint32_t[4]' {aka 'const unsigned int[4]'}
goodbyedpi.c:1516:39: warning: 'dns_handle_outgoing' reading 16 bytes from a region of size 4 [-Wstringop-overread]
goodbyedpi.c:1516:39: note: referencing argument 3 of type 'const uint32_t[4]' {aka 'const unsigned int[4]'}
dnsredir.h:31:5: note: in a call to function 'dns_handle_outgoing'
   31 | int dns_handle_outgoing(const uint32_t srcip[4], const uint16_t srcport,
      |     ^~~~~~~~~~~~~~~~~~~

</p>
</details> 