### PR TITLE
Fix ip header id field sequence in generated packets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,6 @@ jobs:
 
       - name: Install MinGW-w64
         run: >
-          sudo rm /var/lib/man-db/auto-update &&
           sudo DEBIAN_FRONTEND=noninteractive XZ_DEFAULTS="-T0" XZ_OPT="-T0" eatmydata
           apt install -y --no-install-recommends gcc-mingw-w64
 

--- a/src/fakepackets.c
+++ b/src/fakepackets.c
@@ -17,6 +17,7 @@ struct fake_t {
 static struct fake_t *fakes[30] = {0};
 int fakes_count = 0;
 int fakes_resend = 1;
+unsigned int iphdr_id = 0;
 
 static const unsigned char fake_http_request[] = "GET / HTTP/1.1\r\nHost: www.w3.org\r\n"
                                                  "User-Agent: curl/7.65.3\r\nAccept: */*\r\n"
@@ -203,6 +204,13 @@ static int send_fake_data(const HANDLE w_filter,
 
         if (set_ttl)
             ppIpHdr->TTL = set_ttl;
+
+        // ppIpHdr->FragOff0 = ((ppIpHdr->FragOff0) & 0xFFBF) | //uncomment if DF flag must be zero
+        // (((FALSE) & 0x0001) << 6);  
+		
+        ppIpHdr->Id = htons(iphdr_id);
+        iphdr_id++;
+		
     }
     else {
         ppIpV6Hdr->Length = htons(
@@ -283,6 +291,7 @@ int send_fake_http_request(const HANDLE w_filter,
                                   const BYTE set_seq
                                  ) {
     int ret = 0;
+    rand_s(&iphdr_id);
     for (int i=0; i<fakes_count || i == 0; i++) {
         for (int j=0; j<fakes_resend; j++)
             if (send_fake_request(w_filter, addr, pkt, packetLen,
@@ -306,6 +315,7 @@ int send_fake_https_request(const HANDLE w_filter,
                                    const BYTE set_seq
                                  ) {
     int ret = 0;
+    rand_s(&iphdr_id);
     for (int i=0; i<fakes_count || i == 0; i++) {
         for (int j=0; j<fakes_resend; j++)
             if (send_fake_request(w_filter, addr, pkt, packetLen,


### PR DESCRIPTION
Если задана последовательность фейковых пакетов, то в текущем виде все они имеют одинаковое поле Identification в заголовке IP пакета, это сказывается на проходимости DPI такими пакетами. Например для доступа к _*.googlevideo.com_ (Ростелеком) у меня достаточно в Zapret задать: `winws.exe --wf-tcp=443 --dpi-desync=fake --dpi-desync-fooling=badseq --dpi-desync-fake-tls=0x00 --dpi-desync-repeats=20` .
В GoodbyeDPI, в текущей версии программы, аналогичная последовательность  не работает - `goodbyedpi.exe --wrong-seq --fake-from-hex 00 --fake-resend 20` из за того, что вышеуказанное поле всегда имеет одно и то же значение.
Предлагаемый PR исправляет этот момент, и значение в этом поле увеличивается на единицу с каждым сгенерированным пакетом.

If a sequence of fake packets is given, in its current form they all have the same Identification field in the IP packet header, which affects the ability of such packets to pass through DPI. For example, to access *.googlevideo.com (Rostelecom), it is enough for me to set in Zapret: `winws.exe --wf-tcp=443 --dpi-desync=fake --dpi-desync-fooling=badseq --dpi-desync-fake-tls=0x00 --dpi-desync-repeats=20`.
In GoodbyeDPI, a similar sequence in the current version of the program does not work: `goodbyedpi.exe --wrong-seq --fake-from-hex 00 --fake-resend 20` because the aforementioned field always has the same value.
The proposed PR fixes this issue by incrementing value in this field by one, with each generated packet.
