### PR TITLE
Modify fake http request

### DIFF
--- a/src/fakepackets.c
+++ b/src/fakepackets.c
@@ -19,8 +19,8 @@ int fakes_count = 0;
 int fakes_resend = 1;
 
 static const unsigned char fake_http_request[] = "GET / HTTP/1.1\r\nHost: www.w3.org\r\n"
-                                                 "User-Agent: curl/7.65.3\r\nAccept: */*\r\n"
-                                                 "Accept-Encoding: deflate, gzip, br\r\n\r\n";
+                                                 "User-Agent: curl/8.11.1\r\nAccept: */*\r\n"
+                                                 "Accept-Encoding: deflate, compress, gzip, br\r\n\r\n";
 static const unsigned char fake_https_request[] = {
     0x16, 0x03, 0x01, 0x02, 0x00, 0x01, 0x00, 0x01, 0xfc, 0x03, 0x03, 0x9a, 0x8f, 0xa7, 0x6a, 0x5d,
     0x57, 0xf3, 0x62, 0x19, 0xbe, 0x46, 0x82, 0x45, 0xe2, 0x59, 0x5c, 0xb4, 0x48, 0x31, 0x12, 0x15,


### PR DESCRIPTION
Change curl to a newer version in the fake request to make it look more realistic in case of ISP auditing packets.