### PR TITLE
Fix grammar error in README and YAML syntax errors in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,17 +36,17 @@ jobs:
         id: windivert-cache
         uses: actions/cache@v4
         with:
-          path: ${{ env. WINDIVERT_NAME }}
-          key: ${{ env. WINDIVERT_SHA256 }}
+          path: ${{ env.WINDIVERT_NAME }}
+          key: ${{ env.WINDIVERT_SHA256 }}
 
       - name: Download WinDivert from the website
         if: steps.windivert-cache.outputs.cache-hit != 'true'
         run: >
-          wget ${{ env. WINDIVERT_URL }} &&
-          (echo ${{ env. WINDIVERT_SHA256 }} ${{ env. WINDIVERT_NAME }} | sha256sum -c)
+          wget ${{ env.WINDIVERT_URL }} &&
+          (echo ${{ env.WINDIVERT_SHA256 }} ${{ env.WINDIVERT_NAME }} | sha256sum -c)
 
       - name: Unpack WinDivert
-        run: unzip ${{ env. WINDIVERT_NAME }}
+        run: unzip ${{ env.WINDIVERT_NAME }}
 
       - name: Compile x86_64
         run: >

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The program loads WinDivert driver which uses Windows Filtering Platform to set 
 
 # How to build from source
 
-This project can be build using **GNU Make** and [**mingw**](https://mingw-w64.org). The only dependency is [WinDivert](https://github.com/basil00/Divert).
+This project can be built using **GNU Make** and [**mingw**](https://mingw-w64.org). The only dependency is [WinDivert](https://github.com/basil00/Divert).
 
 To build x86 exe run:
 


### PR DESCRIPTION
This commit corrects a grammar error in the README documentation and fixes GitHub Actions workflow environment variable references that had extra spaces preventing proper variable resolution.